### PR TITLE
Update query to get latest migration

### DIFF
--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -10,7 +10,7 @@ export const REGEX_MIGRATION_FILE_NAME = /^\d{10,14}-.+.ts$/;
 let regexFileName = new RegExp(REGEX_MIGRATION_FILE_NAME);
 
 export const QUERY_GET_LATEST =
-  `select ${COL_FILE_NAME} from ${TABLE_MIGRATIONS} order by ${COL_CREATED_AT} desc limit 1`;
+  `select ${COL_FILE_NAME} from ${TABLE_MIGRATIONS} order by ${COL_FILE_NAME} desc limit 1`;
 export const QUERY_INSERT = (fileName: string) =>
   `INSERT INTO ${TABLE_MIGRATIONS} (${COL_FILE_NAME}) VALUES ('${fileName}');`;
 export const QUERY_DELETE = (fileName: string) =>


### PR DESCRIPTION
Fixes #25 
The update query uses `ORDER BY created_at`, this does not register instantaneous time diff between migration runs. Switch it to `ORDER BY file_name` because creating a migration script takes a bit more time, giving us cleanly separated time values.

I didn't go the `max` route because I thought it might break compatibility in `filterAndSortFiles:     if (queryResult === undefined) return true;
` https://github.com/halvardssm/deno-nessie/blob/f981bd4739285fe047c9713c4d237f76efb26d19/cli/utils.ts#L41-L54
since it checks against `undefined` which in turn is in passed from specific db-dialect scripts. 

_A solution for the future maybe setting the `COL_CREATED_AT: created_at` attribute to be time of file creation, not the time of database entry._

I couldn't figure out how to write the tests though, maybe later