### PR TITLE
Fix partial migrations

### DIFF
--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -47,9 +47,9 @@ export const filterAndSortFiles = (
 
     if (queryResult === undefined) return true;
 
-    return parseInt(file.name.split("-")[0]) >
-      new Date(queryResult).getTime();
-  })
+      return file.name > queryResult[0];
+    
+    })
     .sort((a, b) => parseInt(a?.name ?? "0") - parseInt(b?.name ?? "0"));
 };
 

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -42,13 +42,13 @@ export const filterAndSortFiles = (
   files: Deno.DirEntry[],
   queryResult: string | undefined,
 ): Deno.DirEntry[] => {
-  return files.filter((file: Deno.DirEntry): boolean => {
-    if (!regexFileName.test(file.name)) return false;
+  return files
+    .filter((file: Deno.DirEntry): boolean => {
+      if (!regexFileName.test(file.name)) return false;
 
-    if (queryResult === undefined) return true;
+      if (queryResult === undefined) return true;
 
       return file.name > queryResult[0];
-    
     })
     .sort((a, b) => parseInt(a?.name ?? "0") - parseInt(b?.name ?? "0"));
 };


### PR DESCRIPTION
Fixes #26 

The migration scripts worked only when applied in bulk with an empty db table. The comparison was faulty.