### PR TITLE
New test cases for migrations

### DIFF
--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -10,7 +10,7 @@ export const REGEX_MIGRATION_FILE_NAME = /^\d{10,14}-.+.ts$/;
 let regexFileName = new RegExp(REGEX_MIGRATION_FILE_NAME);
 
 export const QUERY_GET_LATEST =
-  `select ${COL_FILE_NAME} from ${TABLE_MIGRATIONS} order by ${COL_CREATED_AT} desc limit 1`;
+  `select ${COL_FILE_NAME} from ${TABLE_MIGRATIONS} order by ${COL_FILE_NAME} desc limit 1`;
 export const QUERY_INSERT = (fileName: string) =>
   `INSERT INTO ${TABLE_MIGRATIONS} (${COL_FILE_NAME}) VALUES ('${fileName}');`;
 export const QUERY_DELETE = (fileName: string) =>
@@ -42,14 +42,14 @@ export const filterAndSortFiles = (
   files: Deno.DirEntry[],
   queryResult: string | undefined,
 ): Deno.DirEntry[] => {
-  return files.filter((file: Deno.DirEntry): boolean => {
-    if (!regexFileName.test(file.name)) return false;
+  return files
+    .filter((file: Deno.DirEntry): boolean => {
+      if (!regexFileName.test(file.name)) return false;
 
-    if (queryResult === undefined) return true;
+      if (queryResult === undefined) return true;
 
-    return parseInt(file.name.split("-")[0]) >
-      new Date(queryResult).getTime();
-  })
+      return file.name > queryResult[0];
+    })
     .sort((a, b) => parseInt(a?.name ?? "0") - parseInt(b?.name ?? "0"));
 };
 

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -48,7 +48,7 @@ export const filterAndSortFiles = (
 
       if (queryResult === undefined) return true;
 
-      return file.name > queryResult[0];
+      return file.name > queryResult;
     })
     .sort((a, b) => parseInt(a?.name ?? "0") - parseInt(b?.name ?? "0"));
 };

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -24,17 +24,17 @@ const strings = [
     solution: ["Nothing to migrate"],
   },
   {
-    name: "Rollback",
+    name: "Rollback Mango",
     string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822650-mango.ts"],
   },
   {
-    name: "Rollback",
+    name: "Rollback Apple",
     string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822649-apple.ts"],
   },
   {
-    name: "Migrate",
+    name: "Migrate Apple and Mango",
     string: TYPE_MIGRATE,
     solution: [
       "Migrated 1587937822649-apple.ts",
@@ -43,17 +43,17 @@ const strings = [
     ],
   },
   {
-    name: "Rollback",
+    name: "Rollback Mango",
     string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822650-mango.ts"],
   },
   {
-    name: "Rollback",
+    name: "Rollback Apple",
     string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822649-apple.ts"],
   },
   {
-    name: "Rollback",
+    name: "Rollback Test",
     string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822648-test.ts"],
   },

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -13,6 +13,8 @@ const strings = [
     solution: [
       "Database setup complete",
       "Migrated 1587937822648-test.ts",
+      "Migrated 1587937822649-apple.ts",
+      "Migrated 1587937822650-mango.ts",
       "Migration complete",
     ],
   },
@@ -24,17 +26,41 @@ const strings = [
   {
     name: "Rollback",
     string: TYPE_ROLLBACK,
+    solution: ["Rolled back 1587937822650-mango.ts"],
+  },
+  {
+    name: "Rollback",
+    string: TYPE_ROLLBACK,
+    solution: ["Rolled back 1587937822649-apple.ts"],
+  },
+  {
+    name: "Migrate",
+    string: TYPE_MIGRATE,
+    solution: [
+      "Migrated 1587937822649-apple.ts",
+      "Migrated 1587937822650-mango.ts",
+      "Migration complete",
+    ],
+  },
+  {
+    name: "Rollback",
+    string: TYPE_ROLLBACK,
+    solution: ["Rolled back 1587937822650-mango.ts"],
+  },
+  {
+    name: "Rollback",
+    string: TYPE_ROLLBACK,
+    solution: ["Rolled back 1587937822649-apple.ts"],
+  },
+  {
+    name: "Rollback",
+    string: TYPE_ROLLBACK,
     solution: ["Rolled back 1587937822648-test.ts"],
   },
   {
     name: "Rollback empty",
     string: TYPE_ROLLBACK,
     solution: ["Nothing to rollback"],
-  },
-  {
-    name: "Migrate",
-    string: TYPE_MIGRATE,
-    solution: ["Migrated 1587937822648-test.ts", "Migration complete"],
   },
 ];
 

--- a/tests/migrations/1587937822649-apple.ts
+++ b/tests/migrations/1587937822649-apple.ts
@@ -1,0 +1,13 @@
+import { Schema } from "../../mod.ts";
+
+export const up = (scema: Schema): void => {
+  scema.create("apple", (table) => {
+    table.id();
+    table.string("col_1", 10);
+    table.timestamps();
+  });
+};
+
+export const down = (schema: Schema): void => {
+  schema.drop("apple");
+};

--- a/tests/migrations/1587937822650-mango.ts
+++ b/tests/migrations/1587937822650-mango.ts
@@ -1,0 +1,13 @@
+import { Schema } from "../../mod.ts";
+
+export const up = (scema: Schema): void => {
+  scema.create("mango", (table) => {
+    table.id();
+    table.string("col_1", 10);
+    table.timestamps();
+  });
+};
+
+export const down = (schema: Schema): void => {
+  schema.drop("mango");
+};


### PR DESCRIPTION
Addresses issues #25 and #26 

The order of migration and rollback test commands are:

1. Create table and migrate all in folder
2. Migrate Empty
3. Rollback * 2
4. Migrate (2)
5. Rollback * 3
6. Rollback empty

I had to change the sequence to be different from what @halvardssm proposed because I couldn't find a way to add new migration scripts in midst of the running tests.