### PR TITLE
fix: pass migration name to makeMigration

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -54,7 +54,7 @@ const run = async () => {
       const state = await new State(prog).init();
 
       if (prog.make) {
-        await state.makeMigration(prog.make);
+        await state.makeMigration(prog.migrationName);
       } else {
         await state.client!.prepare();
 


### PR DESCRIPTION
When creating a new migration the name passed to `makeMigration` function was the flag `prog.make` which was a `boolean`. This resulted in a filename similar to `migrations/1591214975575-true.ts`. This pull fixes this issue.