### PR TITLE
Upgrades 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  DENO_VERSION: 1.1.3
+  DENO_VERSION: 1.2.0
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  DENO_VERSION: 1.2.0
+  DENO_VERSION: 1.2.2
 
 on:
   push:

--- a/clients/ClientMySQL.ts
+++ b/clients/ClientMySQL.ts
@@ -1,4 +1,4 @@
-import { Client, ClientConfig } from "https://deno.land/x/mysql@2.2.0/mod.ts";
+import { Client, ClientConfig } from "https://deno.land/x/mysql@v2.3.0/mod.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import {
   AmountMigrateT,

--- a/clients/ClientPostgreSQL.ts
+++ b/clients/ClientPostgreSQL.ts
@@ -1,6 +1,6 @@
-import { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.1/connection_params.ts";
-import { Client } from "https://deno.land/x/postgres@v0.4.1/mod.ts";
-import { QueryResult } from "https://deno.land/x/postgres@v0.4.1/query.ts";
+import { ConnectionOptions } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/connection_params.ts";
+import { Client } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/mod.ts";
+import { QueryResult } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/query.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import {
   AmountMigrateT,

--- a/clients/ClientPostgreSQL.ts
+++ b/clients/ClientPostgreSQL.ts
@@ -1,6 +1,6 @@
-import { ConnectionOptions } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/connection_params.ts";
-import { Client } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/mod.ts";
-import { QueryResult } from "https://raw.githubusercontent.com/deno-postgres/deno-postgres/e13d42979acc009aa361e1f12edd1aae7d8532c4/query.ts";
+import { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.3/connection_params.ts";
+import { Client } from "https://deno.land/x/postgres@v0.4.3/mod.ts";
+import { QueryResult } from "https://deno.land/x/postgres@v0.4.3/query.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import {
   AmountMigrateT,

--- a/deps.ts
+++ b/deps.ts
@@ -1,10 +1,10 @@
-export { relative, resolve } from "https://deno.land/std@v0.55.0/path/mod.ts";
-export { readJson } from "https://deno.land/std@v0.55.0/fs/read_json.ts";
+export { relative, resolve } from "https://deno.land/std@v0.61.0/path/mod.ts";
+export { readJson } from "https://deno.land/std@v0.61.0/fs/read_json.ts";
 export {
   assert,
   assertArrayContains,
   assertEquals,
-} from "https://deno.land/std@v0.55.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.61.0/testing/asserts.ts";
 
 import Denomander from "https://deno.land/x/denomander@0.6.2/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,10 +1,10 @@
-export { relative, resolve } from "https://deno.land/std@v0.61.0/path/mod.ts";
-export { readJson } from "https://deno.land/std@v0.61.0/fs/read_json.ts";
+export { relative, resolve } from "https://deno.land/std@v0.63.0/path/mod.ts";
+export { readJson } from "https://deno.land/std@v0.63.0/fs/read_json.ts";
 export {
   assert,
   assertArrayContains,
   assertEquals,
-} from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.63.0/testing/asserts.ts";
 
 import Denomander from "https://deno.land/x/denomander@0.6.3/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -6,6 +6,6 @@ export {
   assertEquals,
 } from "https://deno.land/std@v0.61.0/testing/asserts.ts";
 
-import Denomander from "https://deno.land/x/denomander@0.6.2/mod.ts";
+import Denomander from "https://deno.land/x/denomander@0.6.3/mod.ts";
 
 export { Denomander };


### PR DESCRIPTION
Fixes #

## Is this a breaking change?

- [x] Yes
- [ ] No

## Checklist:

Please review the [guidelines for contributing](https://github.com/halvardssm/deno-nessie/blob/master/.github/CONTRIBUTING.md) to this repository.

- [ ] Updated JSDoc (for methods changed/added)
- [ ] Added tests to cover added functionalities.
- [ ] Updated readme (if applicable).
- [ ] Added/updated examples in example folder.
- [ ] Make sure the pipeline passes.

When all of the above is completed, request a review from one of the codeowners.

## Description:

Upgrades dependencies to Deno v1.2 / stdlib v 0.61. The dependency on `deno-postgres` uses a commit hash rather than a true tagged version as the repo doesn't yet have a tagged release that includes the upgrade.

I don't have MySQL or PostgreSQL set up in such a way as to run the client tests.