### PR TITLE
update version denomander and postgres

### DIFF
--- a/clients/ClientPostgreSQL.ts
+++ b/clients/ClientPostgreSQL.ts
@@ -1,6 +1,6 @@
-import type { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.5/connection_params.ts";
-import { Client } from "https://deno.land/x/postgres@v0.4.5/mod.ts";
-import type { QueryResult } from "https://deno.land/x/postgres@v0.4.5/query.ts";
+import type { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.6/connection_params.ts";
+import { Client } from "https://deno.land/x/postgres@v0.4.6/mod.ts";
+import type { QueryResult } from "https://deno.land/x/postgres@v0.4.6/query.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import type {
   AmountMigrateT,

--- a/deps.ts
+++ b/deps.ts
@@ -3,8 +3,9 @@ export {
   assert,
   assertArrayContains,
   assertEquals,
-} from "https://deno.land/std@0.73.0/testing/asserts.ts";
+} from "https://deno.land/std@0.82.0/testing/asserts.ts";
 
-import Denomander from "https://deno.land/x/denomander@0.6.3/mod.ts";
+// Denomander v.0.7.01
+import Denomander from "https://raw.githubusercontent.com/siokas/denomander/f0ce9c1c0a758a5df4e886e03277388c74658859/mod.ts";
 
 export { Denomander };

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { relative, resolve } from "https://deno.land/std@0.73.0/path/mod.ts";
+export { relative, resolve } from "https://deno.land/std@0.82.0/path/mod.ts";
 export {
   assert,
   assertArrayContains,

--- a/deps.ts
+++ b/deps.ts
@@ -6,6 +6,6 @@ export {
 } from "https://deno.land/std@0.82.0/testing/asserts.ts";
 
 // Denomander v.0.7.01
-import Denomander from "https://raw.githubusercontent.com/siokas/denomander/f0ce9c1c0a758a5df4e886e03277388c74658859/mod.ts";
+import Denomander from "https://denopkg.com/siokas/denomander@0.7.01/mod.ts";
 
 export { Denomander };

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,7 @@
 export { relative, resolve } from "https://deno.land/std@0.82.0/path/mod.ts";
 export {
   assert,
-  assertArrayContains,
+  assertArrayIncludes,
   assertEquals,
 } from "https://deno.land/std@0.82.0/testing/asserts.ts";
 


### PR DESCRIPTION
Fixes error deno version 1.6.2
------------
updated the **Postgre** v0.4.5 to v0.4.6 and **Denomander** v0.6.3 to v0.7.01

use with deno version >= 1.6.2
