### PR TITLE
Update package version

### DIFF
--- a/clients/ClientMySQL.ts
+++ b/clients/ClientMySQL.ts
@@ -1,4 +1,4 @@
-import { Client, ClientConfig } from "https://deno.land/x/mysql@v2.4.0/mod.ts";
+import { Client, ClientConfig } from "https://deno.land/x/mysql@v2.7.0/mod.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import type {
   AmountMigrateT,

--- a/clients/ClientPostgreSQL.ts
+++ b/clients/ClientPostgreSQL.ts
@@ -1,6 +1,6 @@
-import type { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.5/connection_params.ts";
-import { Client } from "https://deno.land/x/postgres@v0.4.5/mod.ts";
-import type { QueryResult } from "https://deno.land/x/postgres@v0.4.5/query.ts";
+import type { ConnectionOptions } from "https://deno.land/x/postgres@v0.4.6/connection_params.ts";
+import { Client } from "https://deno.land/x/postgres@v0.4.6/mod.ts";
+import type { QueryResult } from "https://deno.land/x/postgres@v0.4.6/query.ts";
 import { AbstractClient } from "./AbstractClient.ts";
 import type {
   AmountMigrateT,

--- a/deps.ts
+++ b/deps.ts
@@ -3,8 +3,9 @@ export {
   assert,
   assertArrayContains,
   assertEquals,
-} from "https://deno.land/std@0.73.0/testing/asserts.ts";
+} from "https://deno.land/std@0.82.0/testing/asserts.ts";
 
-import Denomander from "https://deno.land/x/denomander@0.6.3/mod.ts";
+// Denomander v.0.7.01
+import Denomander from "https://raw.githubusercontent.com/siokas/denomander/f0ce9c1c0a758a5df4e886e03277388c74658859/mod.ts";
 
 export { Denomander };

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-export { relative, resolve } from "https://deno.land/std@0.73.0/path/mod.ts";
+export { relative, resolve } from "https://deno.land/std@0.82.0/path/mod.ts";
 export {
   assert,
   assertArrayContains,

--- a/deps.ts
+++ b/deps.ts
@@ -6,6 +6,6 @@ export {
 } from "https://deno.land/std@0.82.0/testing/asserts.ts";
 
 // Denomander v.0.7.01
-import Denomander from "https://raw.githubusercontent.com/siokas/denomander/f0ce9c1c0a758a5df4e886e03277388c74658859/mod.ts";
+import Denomander from "https://denopkg.com/siokas/denomander@0.7.01/mod.ts";
 
 export { Denomander };

--- a/deps.ts
+++ b/deps.ts
@@ -1,7 +1,7 @@
 export { relative, resolve } from "https://deno.land/std@0.82.0/path/mod.ts";
 export {
   assert,
-  assertArrayContains,
+  assertArrayIncludes,
   assertEquals,
 } from "https://deno.land/std@0.82.0/testing/asserts.ts";
 


### PR DESCRIPTION
Fixes run cache error deno v.1.6.2

update MySQL v.2.4.0 to 2.7.0
update Postgres v.0.4.5 to v.0.4.6
update Denomander v.0.6.3 to v.0.7.01

Can be used with deno version> = 1.6.2 👍 